### PR TITLE
add missing config code, optimizing import of react dom

### DIFF
--- a/dashboard/static/src/js/Index.js
+++ b/dashboard/static/src/js/Index.js
@@ -1,6 +1,6 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { render } from 'react-dom';
 import App from "./App";
 
 // entry point
-ReactDOM.render(<App />, document.getElementById("content"));
+render(<App />, document.getElementById("content"));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,11 @@ const config = {
     },
     module: {
         rules: [
+          //parse css files
+          {
+            test: /\.css$/,
+            loader:[ 'style-loader', 'css-loader']
+          },
           {
             test: /\.(png|jpe?g|gif)$/i,
             loader: 'url-loader'


### PR DESCRIPTION
add missing code to parse css file via loader in webpack config file
optimizing import of react dom library (only import method needed, not the entire lib, to optimizing build)