### PR TITLE
Add docker continuous delivery

### DIFF
--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -14,7 +14,7 @@ jobs:
         # todo: pin to hash
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
-          name: ${{ env.GITHUB_REPOSITORY }}
+          name: ${{ github.repository }}
           # configured at repo settings/secrets
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -14,7 +14,7 @@ jobs:
         # todo: pin to hash
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
-          name: uwcirg/map-api
+          name: ${{ GITHUB_REPOSITORY }}
           # configured at repo settings/secrets
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -1,0 +1,21 @@
+# docker continuous delivery
+# deliver docker images to configured repo with tags to match branches and git tags
+---
+name: Publish Docker
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout git commit
+        uses: actions/checkout@master
+
+      - name: Publish to Dockerhub registry
+        # todo: pin to hash
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: uwcirg/map-api
+          # configured at repo settings/secrets
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tag_semver: true

--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -14,6 +14,7 @@ jobs:
         # todo: pin to hash
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
+          # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
           name: ${{ github.repository }}
           # configured at repo settings/secrets
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -14,7 +14,7 @@ jobs:
         # todo: pin to hash
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
-          name: ${{ GITHUB_REPOSITORY }}
+          name: ${{ env.GITHUB_REPOSITORY }}
           # configured at repo settings/secrets
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
* Push docker images to match git tags and branches
* Use [semantic versioning](https://github.com/marketplace/actions/publish-docker#tag_semver)(see below)

>Use tag_semver when you want to push tags using the semver syntax by their git name (e.g. refs/tags/v1.2.3). This will push four docker tags: 1.2.3, 1.2 and 1. A prefix 'v' will automatically be removed.