### PR TITLE
Bundle analyzer plugin update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ client_secrets.json
 dashboard.env
 dashboard/static/js
 dashboard/templates/index.html
+dashboard/static/public/dashboard_bundles_report.html
 package-lock.json
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ client_secrets.json
 dashboard.env
 dashboard/static/js
 dashboard/templates/index.html
-dashboard/static/public/dashboard_bundles_report.html
+report.*
 package-lock.json
 node_modules

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "build": "webpack -p --progress --config webpack.config.js",
-    "dev-build": "webpack --progress -d --config webpack.config.js",
-    "watch": "webpack --progress -d --config webpack.config.js --watch",
+    "dev-build": "webpack --progress  --debug --config webpack.config.js",
+    "watch": "webpack --progress  --debug --config webpack.config.js --watch",
     "report": "npm run build && webpack --profile --json > report.json && webpack-bundle-analyzer report.json  ./dashboard/static/js  -m static"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "webpack -p --progress --config webpack.config.js",
     "dev-build": "webpack --progress -d --config webpack.config.js",
     "watch": "webpack --progress -d --config webpack.config.js --watch",
-    "report": "webpack --profile --json > report.json && webpack-bundle-analyzer report.json  ./dashboard/static/js  -m static"
+    "report": "npm run build && webpack --profile --json > report.json && webpack-bundle-analyzer report.json  ./dashboard/static/js  -m static"
   },
   "dependencies": {
     "@babel/core": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "build": "webpack -p --progress --config webpack.config.js",
     "dev-build": "webpack --progress -d --config webpack.config.js",
-    "watch": "webpack --progress -d --config webpack.config.js --watch"
+    "watch": "webpack --progress -d --config webpack.config.js --watch",
+    "report": "webpack --profile --json > report.json && webpack-bundle-analyzer report.json  ./dashboard/static/js  -m static"
   },
   "dependencies": {
     "@babel/core": "7.2.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const path = require('path');
 const TerserWebpackPlugin = require("terser-webpack-plugin");
 const OptimizeCssAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const config = {
     entry:  path.join(__dirname, '/dashboard/static/src/js/Index.js'),
@@ -53,6 +54,15 @@ const config = {
         title: "StayHome Dashboard",
         template: path.join(__dirname, '/dashboard/static/src/index.html'),
         filename: path.join(__dirname, '/dashboard/templates/index.html')
+      }),
+      /*
+       * navigate to [server name/dev instance]/static/public/dashboard_bundles_report.html to view analysis after a build
+       */
+      new BundleAnalyzerPlugin({
+        analyzerMode: "static",
+        statsFilename: "dashboard_bundles.json",
+        generateStatsFile: true,
+        reportFilename: path.join(__dirname, '/dashboard/static/public/dashboard_bundles_report.html')
       })
     ],
     optimization: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ const path = require('path');
 const TerserWebpackPlugin = require("terser-webpack-plugin");
 const OptimizeCssAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const config = {
     entry:  path.join(__dirname, '/dashboard/static/src/js/Index.js'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,15 +54,6 @@ const config = {
         title: "StayHome Dashboard",
         template: path.join(__dirname, '/dashboard/static/src/index.html'),
         filename: path.join(__dirname, '/dashboard/templates/index.html')
-      }),
-      /*
-       * navigate to [server name/dev instance]/static/public/dashboard_bundles_report.html to view analysis after a build
-       */
-      new BundleAnalyzerPlugin({
-        analyzerMode: "static",
-        statsFilename: "dashboard_bundles.json",
-        generateStatsFile: true,
-        reportFilename: path.join(__dirname, '/dashboard/static/public/dashboard_bundles_report.html')
       })
     ],
     optimization: {


### PR DESCRIPTION
add a helper npm command to run bundle analysis report after a frontend code build to analyze the bundle size of each output file - this allows for tracking for which bundle might need optimization.